### PR TITLE
Uninitialized union constructor

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1740,11 +1740,13 @@ class basic_json
 
                 case value_t::null:
                 {
+                    object = nullptr;
                     break;
                 }
 
                 default:
                 {
+                    object = nullptr;
                     if (t == value_t::null)
                     {
                         JSON_THROW(std::domain_error("961c151d2e87f2686a955a9be24d316f1362bf21 2.1.1")); // LCOV_EXCL_LINE


### PR DESCRIPTION
## Issue

When compiling `orion_proto` in Release mode (not reproducible with Debug) with GCC 12.2.1, it errors out with a confusing error message (see "Compiler Error" section below):

Turns out that the issue that is being reported is around the uninitialized `json_value` union type which is present in `basic_json::m_value`. Turns out that the fix has already been applied to the forked repository ([see here](https://github.com/nlohmann/json/commit/430f03512cfbd7cb629f7f77debe813f1f3b10db)). I've picked out only the necessary changes to overcome this issue.

**NOTE**: I've made sure that the issues were not due to some missing flags to inform the compiler that the JSON library should be treated as a third party library, even with that enabled this issue still takes place. This is a fundamental issue around code optimization that the compiler can't resolve because of uninitialized valuesin the union class.

## Compiler Error

```
/usr/lib64/ccache/g++ -DGFLAGS_IS_A_DLL=0 -I/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/include -I/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/gnss-converters/c/gnss_converters/include -I/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/gnss-converters/c/third_party/libswiftnav/include -I/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/gnss-converters/c/third_party/libsbp/c/include -I/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/build/release/gcc-system/third_party/gnss-converters/c/third_party/libsbp/c/src -I/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/gnss-converters/c/librtcm/include -I/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/gnss-converters/c/libubx/include -I/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/gnss-converters/c/libixcom/include -I/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/gnss-converters/c/gnss_converters_extra/include -isystem /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/protobuf/src -isystem /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/sip/include -isystem /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/build/release/gcc-system/third_party/sip/include -isystem /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/build/release/gcc-system/third_party/sip/include/proto -isystem /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/build/release/gcc-system/third_party/googleflags/include -isystem /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/sip/third_party/Optional -isystem /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/variant/include -isystem /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src -isystem /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/build/release/gcc-system/include -g -rdynamic -O2 -g -DNDEBUG -fdiagnostics-color=always -UNDEBUG -fexceptions -frtti -Werror -Wno-error=deprecated-declarations -Wall -Wcast-align -Wcast-qual -Wchar-subscripts -Wcomment -Wconversion -Wdisabled-optimization -Wextra -Wfloat-equal -Wformat -Wimplicit-fallthrough -Wimport -Winit-self -Winvalid-pch -Wmissing-braces -Wmissing-field-initializers -Wmissing-include-dirs -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wsequence-point -Wshadow -Wsign-compare -Wstack-protector -Wswitch -Wswitch-default -Wswitch-enum -Wtrigraphs -Wuninitialized -Wunknown-pragmas -Wunreachable-code -Wunused -Wunused-function -Wunused-label -Wunused-parameter -Wunused-value -Wunused-variable -Wvolatile-register-var -Wwrite-strings -pedantic -std=c++14 -MD -MT CMakeFiles/orion-proto.dir/src/json_file_reader.cc.o -MF CMakeFiles/orion-proto.dir/src/json_file_reader.cc.o.d -o CMakeFiles/orion-proto.dir/src/json_file_reader.cc.o -c /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/src/json_file_reader.cc
In file included from /usr/include/c++/12/bits/stl_pair.h:61,
                 from /usr/include/c++/12/bits/stl_algobase.h:64,
                 from /usr/include/c++/12/algorithm:60,
                 from /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:32,
                 from /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/include/orion/proto/json.h:16,
                 from /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/include/orion/proto/json_file_reader.h:16,
                 from /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/src/json_file_reader.cc:13:
In function ‘std::_Require<std::__not_<std::__is_tuple_like<_Tp> >, std::is_move_constructible<_Tp>, std::is_move_assignable<_Tp> > std::swap(_Tp&, _Tp&) [with _Tp = nlohmann::basic_json<>::json_value]’,
    inlined from ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::value_type& nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::operator=(nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’ at /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:2554:13,
    inlined from ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer> nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parser::parse_internal(bool) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’ at /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:11421:36:
/usr/include/c++/12/bits/move.h:205:7: error: ‘<unnamed>.nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long int, long unsigned int, double, std::allocator, nlohmann::adl_serializer>::m_value’ may be used uninitialized [-Werror=maybe-uninitialized]
  205 |       __a = _GLIBCXX_MOVE(__b);
      |       ^~~
/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp: In member function ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer> nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parser::parse_internal(bool) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’:
/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:11421:38: note: ‘<anonymous>’ declared here
11421 |                             result = basic_json(value_t::discarded);
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘std::_Require<std::__not_<std::__is_tuple_like<_Tp> >, std::is_move_constructible<_Tp>, std::is_move_assignable<_Tp> > std::swap(_Tp&, _Tp&) [with _Tp = nlohmann::basic_json<>::json_value]’,
    inlined from ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::value_type& nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::operator=(nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’ at /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:2554:13,
    inlined from ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer> nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parser::parse_internal(bool) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’ at /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:11475:32:
/usr/include/c++/12/bits/move.h:205:7: error: ‘<unnamed>.nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long int, long unsigned int, double, std::allocator, nlohmann::adl_serializer>::m_value’ may be used uninitialized [-Werror=maybe-uninitialized]
  205 |       __a = _GLIBCXX_MOVE(__b);
      |       ^~~
/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp: In member function ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer> nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parser::parse_internal(bool) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’:
/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:11475:34: note: ‘<anonymous>’ declared here
11475 |                         result = basic_json(value_t::discarded);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘std::_Require<std::__not_<std::__is_tuple_like<_Tp> >, std::is_move_constructible<_Tp>, std::is_move_assignable<_Tp> > std::swap(_Tp&, _Tp&) [with _Tp = nlohmann::basic_json<>::json_value]’,
    inlined from ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::value_type& nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::operator=(nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’ at /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:2554:13,
    inlined from ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer> nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parser::parse_internal(bool) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’ at /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:11500:36:
/usr/include/c++/12/bits/move.h:205:7: error: ‘<unnamed>.nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long int, long unsigned int, double, std::allocator, nlohmann::adl_serializer>::m_value’ may be used uninitialized [-Werror=maybe-uninitialized]
  205 |       __a = _GLIBCXX_MOVE(__b);
      |       ^~~
/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp: In member function ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer> nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parser::parse_internal(bool) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’:
/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:11500:38: note: ‘<anonymous>’ declared here
11500 |                             result = basic_json(value_t::discarded);
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘std::_Require<std::__not_<std::__is_tuple_like<_Tp> >, std::is_move_constructible<_Tp>, std::is_move_assignable<_Tp> > std::swap(_Tp&, _Tp&) [with _Tp = nlohmann::basic_json<>::json_value]’,
    inlined from ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::value_type& nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::operator=(nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’ at /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:2554:13,
    inlined from ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer> nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parser::parse_internal(bool) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’ at /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:11531:32:
/usr/include/c++/12/bits/move.h:205:7: error: ‘<unnamed>.nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long int, long unsigned int, double, std::allocator, nlohmann::adl_serializer>::m_value’ may be used uninitialized [-Werror=maybe-uninitialized]
  205 |       __a = _GLIBCXX_MOVE(__b);
      |       ^~~
/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp: In member function ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer> nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parser::parse_internal(bool) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’:
/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:11531:34: note: ‘<anonymous>’ declared here
11531 |                         result = basic_json(value_t::discarded);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘std::_Require<std::__not_<std::__is_tuple_like<_Tp> >, std::is_move_constructible<_Tp>, std::is_move_assignable<_Tp> > std::swap(_Tp&, _Tp&) [with _Tp = nlohmann::basic_json<>::json_value]’,
    inlined from ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::value_type& nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::operator=(nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’ at /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:2554:13,
    inlined from ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer> nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parser::parse_internal(bool) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’ at /home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:11586:24:
/usr/include/c++/12/bits/move.h:205:7: error: ‘<unnamed>.nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long int, long unsigned int, double, std::allocator, nlohmann::adl_serializer>::m_value’ may be used uninitialized [-Werror=maybe-uninitialized]
  205 |       __a = _GLIBCXX_MOVE(__b);
      |       ^~~
/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp: In member function ‘nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer> nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parser::parse_internal(bool) [with ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer]’:
/home/rodrigor/Workspace/swift-nav/phoebe/third_party/orion_proto/third_party/json/src/json.hpp:11586:26: note: ‘<anonymous>’ declared here
11586 |                 result = basic_json(value_t::discarded);
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```