### PR TITLE
[CLDAPPS-896] C++20 fix up

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1631,7 +1631,7 @@ class basic_json
             alloc.deallocate(object, 1);
         };
         std::unique_ptr<T, decltype(deleter)> object(alloc.allocate(1), deleter);
-        alloc.construct(object.get(), std::forward<Args>(args)...);
+        new(object.get()) T(std::forward<Args>(args)...);
         assert(object != nullptr);
         return object.release();
     }
@@ -2583,7 +2583,7 @@ class basic_json
             case value_t::object:
             {
                 AllocatorType<object_t> alloc;
-                alloc.destroy(m_value.object);
+                m_value.object->~object_t();
                 alloc.deallocate(m_value.object, 1);
                 break;
             }
@@ -2591,7 +2591,7 @@ class basic_json
             case value_t::array:
             {
                 AllocatorType<array_t> alloc;
-                alloc.destroy(m_value.array);
+                m_value.array->~array_t();
                 alloc.deallocate(m_value.array, 1);
                 break;
             }
@@ -2599,7 +2599,7 @@ class basic_json
             case value_t::string:
             {
                 AllocatorType<string_t> alloc;
-                alloc.destroy(m_value.string);
+                m_value.string->~string_t();
                 alloc.deallocate(m_value.string, 1);
                 break;
             }


### PR DESCRIPTION
# Changes

When trying to use this library with C++20 it fails because some functions have been deprecated as of C++20. Specifically:

* [std::allocator<T>::construct](https://en.cppreference.com/w/cpp/memory/allocator/construct)
* [std::allocator<T>::destroy](https://en.cppreference.com/w/cpp/memory/allocator/destroy)

These changes make sure that the library can be compiled with C++20.