### PR TITLE
Upgrade YAML to fix with modern libstd library

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -33,7 +33,6 @@ SOFTWARE.
 #include <array> // array
 #include <cassert> // assert
 #include <cctype> // isdigit
-#include <ciso646> // and, not, or
 #include <cmath> // isfinite, labs, ldexp, signbit
 #include <cstddef> // nullptr_t, ptrdiff_t, size_t
 #include <cstdint> // int64_t, uint64_t


### PR DESCRIPTION
# Changes

Trying to compile this with the latest C++ compiler yields an error because `#include <ciso646>` has been removed in C++20. See https://en.cppreference.com/w/cpp/header/ciso646. The use of this library is to support version prior to C++98 which didn't have `and`, `or`, and `not` keywords.