### PR TITLE
Fix disabling exceptions

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -89,7 +89,7 @@ SOFTWARE.
 #endif
 
 // allow to disable exceptions
-#if not defined(JSON_NOEXCEPTION) || defined(__EXCEPTIONS)
+#if not defined(JSON_NOEXCEPTION) && defined(__EXCEPTIONS)
     #define JSON_THROW(exception) throw exception
     #define JSON_TRY try
     #define JSON_CATCH(exception) catch(exception)


### PR DESCRIPTION
Fix a badly written macro which is trying to detect whether or not exceptions can be enabled but ends up completely ignoring `-fno-exceptions` passed on the command line